### PR TITLE
Fix Chrome "open page in new tab" waiting for page focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+.DS_Store

--- a/src/donate.js
+++ b/src/donate.js
@@ -81,16 +81,18 @@ window.WebMonetizationScripts.donate = async function ({
   async function initConnection () {
     // Don't do anything if the page is hidden because web monetization won't
     // work. just wait.
-    if (document.hidden) {
+    if (document.hidden || !document.hasFocus()) {
       await new Promise(resolve => {
         function onVisible () {
-          if (!document.hidden) {
+          if (!document.hidden && document.hasFocus()) {
             resolve()
             document.removeEventListener('visibilitychange', onVisible)
+            window.removeEventListener('focus', onVisible)
           }
         }
 
         document.addEventListener('visibilitychange', onVisible, false)
+        window.addEventListener('focus', onVisible, false)
       })
     }
 


### PR DESCRIPTION
At command-click on a link a page is opened in a new tab. `document.hidden` is false, **and** `document.hasFocus()` is false, init doesn't work. Wait for both. (Tested on OSX)